### PR TITLE
HTTP server functions - new alert & retrieve all currently defined alerts

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -8,22 +8,23 @@ import (
 	"net/http"
 )
 
-func HTTPServer(ctx context.Context, itemTradeHistory store.TradeStore) error {
+func HTTPServer(ctx context.Context, itemTradeHistory store.TradeStore, alertsDefined store.AlertDefStore) error {
 
 	//Create a mux router instance which can be used assign routes to etc.
 	r := mux.NewRouter()
 
 	//Define the routes
 	r.HandleFunc("/item_traded/{id}", GetTradesByItemHandler(ctx, itemTradeHistory)).Methods("GET")
+	r.HandleFunc("/create_alert/{id}", CreateNewAlertHandler(ctx, alertsDefined)).Methods("POST")
+	r.HandleFunc("/all_defined_alerts", GetAllDefinedAlertsHandler(ctx, alertsDefined)).Methods("GET")
 
-	//Start the server
-	//log.Fatal(http.ListenAndServe(":8080", r))
-
+	//Check if the context has been cancelled
 	if ctx.Err() != nil {
 		fmt.Printf("Context error:%v", ctx.Err())
 		return ctx.Err()
 	}
 
+	//Start the server
 	httpError := http.ListenAndServe(":8080", r)
 
 	if httpError != nil {

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -6,9 +6,12 @@ import (
 	store "Price_Notification_System/store"
 	"context"
 	"encoding/json"
+	"fmt"
 	"github.com/gorilla/mux"
 	"log"
 	"net/http"
+	"strconv"
+	"strings"
 )
 
 func GetTradesByItemHandler(ctx context.Context, itemTradeHistory store.TradeStore) http.HandlerFunc {
@@ -42,4 +45,96 @@ func GetTradesByItemHandler(ctx context.Context, itemTradeHistory store.TradeSto
 			log.Fatal("The HTTP server failed to return the results due to error: ", errWrite)
 		}
 	}
+}
+
+func CreateNewAlertHandler(ctx context.Context, alertsDefined store.AlertDefStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		//Return a 200 OK response
+		w.WriteHeader(http.StatusOK)
+
+		//Create a var to store the response in
+		var responseConfirmationString string
+		var responseConfirmationStringJSON []byte
+
+		//Create key-value pairs (map) from the URL
+		vars := mux.Vars(r)
+
+		//Obtain from the url which item we are interested in reporting - expected format is item,alertType,priceTrigger
+		newAlertDetails := vars["id"]
+
+		// Split out the new alert details
+		item, alertType, priceTrigger, err := CreateNewAlertIDSplit(newAlertDetails)
+		if err != nil {
+			responseConfirmationString = fmt.Sprintf("There was an error trying to get the item details from the url.  Error: %v", err)
+			responseConfirmationStringJSON, _ = json.Marshal(responseConfirmationString)
+			_, _ = w.Write(responseConfirmationStringJSON)
+			return
+		}
+
+		//Call the function from the service package
+		err = service.CreateNewAlert(ctx, alertsDefined, item, models.AlertValues{AlertType: alertType, PriceTrigger: priceTrigger})
+		//results, err = service.ProcessAlerts(ctx, alertsDefined, itemsToReport)
+		if err != nil {
+			responseConfirmationString = fmt.Sprintf("The HTTP server failed to get the results due to error: %v", err)
+			responseConfirmationStringJSON, _ = json.Marshal(responseConfirmationString)
+			_, _ = w.Write(responseConfirmationStringJSON)
+			return
+		}
+
+		// If the alert was created successfully, return a confirmation message
+		responseConfirmationString = fmt.Sprintf("The alert for item %s has been created successfully.\n The alert type is %d, and the price trigger is %d", item, alertType, priceTrigger)
+		responseConfirmationStringJSON, _ = json.Marshal(responseConfirmationString)
+		_, _ = w.Write(responseConfirmationStringJSON)
+
+	}
+}
+
+func GetAllDefinedAlertsHandler(ctx context.Context, alertsDefined store.AlertDefStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		//Convert the results to JSON in readiness to respond with the results
+		resultsJSON, err := json.Marshal(alertsDefined)
+		if err != nil {
+			errJSON, _ := json.Marshal(err)
+			_, _ = w.Write(errJSON)
+			return
+		}
+
+		//Write the results to the
+		_, errWrite := w.Write(resultsJSON)
+		if errWrite != nil {
+			errWriteJSON, _ := json.Marshal(errWrite)
+			_, _ = w.Write(errWriteJSON)
+		}
+	}
+}
+
+func CreateNewAlertIDSplit(newAlertDetails string) (item string, alertType models.AlertType, priceTrigger int, err error) {
+	// Create a temporary variable to hold the alert type as a string & price trigger as an int64
+	var alertTypeAsString string
+	var alertTypeInt int
+
+	// Split the new alert details into item, alert type and price trigger
+	alertDetails := strings.Split(newAlertDetails, ",")
+
+	if len(alertDetails) != 3 {
+		return "", 0, 0, fmt.Errorf("invalid alert details format")
+	}
+
+	item = alertDetails[0]
+	alertTypeAsString = alertDetails[1]
+	priceTrigger, err = strconv.Atoi(alertDetails[2])
+	if err != nil {
+		return "", 0, 0, fmt.Errorf("invalid new alert details format")
+	}
+
+	// Convert the alert type string to the AlertType enum
+	alertTypeInt, err = strconv.Atoi(alertTypeAsString)
+	if err != nil {
+		return "", 0, 0, fmt.Errorf("invalid alert type format")
+	}
+
+	alertType = models.AlertType(alertTypeInt)
+
+	return item, alertType, priceTrigger, nil
 }

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -30,19 +30,19 @@ func GetTradesByItemHandler(ctx context.Context, itemTradeHistory store.TradeSto
 		//Call the function from the service package
 		results, err = service.GetTradesByItem(ctx, itemTradeHistory, itemsToReport)
 		if err != nil {
-			log.Fatal("The HTTP server failed to get the results due to error: ", err)
+			log.Println("The HTTP server failed to get the results due to error: ", err)
 		}
 
 		//Convert the results to JSON in readiness to respond with the results
 		resultsJSON, err := json.Marshal(results)
 		if err != nil {
-			log.Fatal("The HTTP server failed to get the results due to error: ", err)
+			log.Println("The HTTP server failed to get the results due to error: ", err)
 		}
 
 		//Write the results to the
 		_, errWrite := w.Write(resultsJSON)
 		if errWrite != nil {
-			log.Fatal("The HTTP server failed to return the results due to error: ", errWrite)
+			log.Println("The HTTP server failed to get the results due to error: ", err)
 		}
 	}
 }
@@ -67,7 +67,10 @@ func CreateNewAlertHandler(ctx context.Context, alertsDefined store.AlertDefStor
 		if err != nil {
 			responseConfirmationString = fmt.Sprintf("There was an error trying to get the item details from the url.  Error: %v", err)
 			responseConfirmationStringJSON, _ = json.Marshal(responseConfirmationString)
-			_, _ = w.Write(responseConfirmationStringJSON)
+			_, err = w.Write(responseConfirmationStringJSON)
+			if err != nil {
+				log.Print("Error writing response: ", err)
+			}
 			return
 		}
 
@@ -77,14 +80,20 @@ func CreateNewAlertHandler(ctx context.Context, alertsDefined store.AlertDefStor
 		if err != nil {
 			responseConfirmationString = fmt.Sprintf("The HTTP server failed to get the results due to error: %v", err)
 			responseConfirmationStringJSON, _ = json.Marshal(responseConfirmationString)
-			_, _ = w.Write(responseConfirmationStringJSON)
+			_, err = w.Write(responseConfirmationStringJSON)
+			if err != nil {
+				log.Print("Error writing response: ", err)
+			}
 			return
 		}
 
 		// If the alert was created successfully, return a confirmation message
 		responseConfirmationString = fmt.Sprintf("The alert for item %s has been created successfully.\n The alert type is %d, and the price trigger is %d", item, alertType, priceTrigger)
 		responseConfirmationStringJSON, _ = json.Marshal(responseConfirmationString)
-		_, _ = w.Write(responseConfirmationStringJSON)
+		_, err = w.Write(responseConfirmationStringJSON)
+		if err != nil {
+			log.Print("Error writing response: ", err)
+		}
 
 	}
 }
@@ -92,8 +101,18 @@ func CreateNewAlertHandler(ctx context.Context, alertsDefined store.AlertDefStor
 func GetAllDefinedAlertsHandler(ctx context.Context, alertsDefined store.AlertDefStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 
+		dataAlertsDefined, err := alertsDefined.GetAllAlerts()
+		if err != nil {
+			marshalledError, _ := json.Marshal(err)
+			_, errWrite := w.Write(marshalledError)
+			if errWrite != nil {
+				log.Println("The HTTP server failed to get the results due to error: ", err)
+			}
+			return
+		}
+
 		//Convert the results to JSON in readiness to respond with the results
-		resultsJSON, err := json.Marshal(alertsDefined)
+		resultsJSON, err := json.Marshal(dataAlertsDefined)
 		if err != nil {
 			errJSON, _ := json.Marshal(err)
 			_, _ = w.Write(errJSON)

--- a/api/tests/handlers_get_all_defined_alerts_handler_test.go
+++ b/api/tests/handlers_get_all_defined_alerts_handler_test.go
@@ -26,7 +26,7 @@ func TestGetAllDefinedAlertsHandler(t *testing.T) {
 				{Item: "item1", AlertValues: models.AlertValues{AlertType: models.PriceAlertLowPrice, PriceTrigger: 100}},
 				{Item: "item2", AlertValues: models.AlertValues{AlertType: models.PriceAlertHighPrice, PriceTrigger: 200}},
 			}),
-			expected: []byte(`{"Data":[{"Item":"item1","AlertType":0,"PriceTrigger":100},{"Item":"item2","AlertType":1,"PriceTrigger":200}]}`),
+			expected: []byte(`{"data":[{"Item":"item1","AlertType":0,"PriceTrigger":100},{"Item":"item2","AlertType":1,"PriceTrigger":200}]}`),
 			wantErr:  false,
 		},
 		{testInstanceName: "test2 - Get all defined alerts",
@@ -34,7 +34,7 @@ func TestGetAllDefinedAlertsHandler(t *testing.T) {
 				{Item: "item3", AlertValues: models.AlertValues{AlertType: 0, PriceTrigger: 300}},
 				{Item: "item4", AlertValues: models.AlertValues{AlertType: 1, PriceTrigger: 400}},
 			}),
-			expected: []byte(`{"Data":[{"Item":"item3","AlertType":0,"PriceTrigger":300},{"Item":"item4","AlertType":1,"PriceTrigger":400}]}`),
+			expected: []byte(`{"data":[{"Item":"item3","AlertType":0,"PriceTrigger":300},{"Item":"item4","AlertType":1,"PriceTrigger":400}]}`),
 			wantErr:  false,
 		},
 	}

--- a/api/tests/handlers_get_all_defined_alerts_handler_test.go
+++ b/api/tests/handlers_get_all_defined_alerts_handler_test.go
@@ -1,0 +1,75 @@
+package api
+
+import (
+	"Price_Notification_System/api"
+	"Price_Notification_System/models"
+	"Price_Notification_System/store"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetAllDefinedAlertsHandler(t *testing.T) {
+
+	type testDef struct {
+		testInstanceName string
+		alertsDefined    store.AlertDefStore
+		expected         []byte
+		wantErr          bool
+	}
+
+	// Define a slice of testDef structs
+	tests := []testDef{
+		{testInstanceName: "test1 - Get all defined alerts",
+			alertsDefined: store.NewInMemoryAlertStoreWithData(&[]models.AlertDef{
+				{Item: "item1", AlertValues: models.AlertValues{AlertType: models.PriceAlertLowPrice, PriceTrigger: 100}},
+				{Item: "item2", AlertValues: models.AlertValues{AlertType: models.PriceAlertHighPrice, PriceTrigger: 200}},
+			}),
+			expected: []byte(`{"Data":[{"Item":"item1","AlertType":0,"PriceTrigger":100},{"Item":"item2","AlertType":1,"PriceTrigger":200}]}`),
+			wantErr:  false,
+		},
+		{testInstanceName: "test2 - Get all defined alerts",
+			alertsDefined: store.NewInMemoryAlertStoreWithData(&[]models.AlertDef{
+				{Item: "item3", AlertValues: models.AlertValues{AlertType: 0, PriceTrigger: 300}},
+				{Item: "item4", AlertValues: models.AlertValues{AlertType: 1, PriceTrigger: 400}},
+			}),
+			expected: []byte(`{"Data":[{"Item":"item3","AlertType":0,"PriceTrigger":300},{"Item":"item4","AlertType":1,"PriceTrigger":400}]}`),
+			wantErr:  false,
+		},
+	}
+
+	// Iterate over the test cases
+	for _, tt := range tests {
+		t.Run(tt.testInstanceName, func(t *testing.T) {
+
+			// Create a new HTTP request to pass to the handler
+			req, err := http.NewRequest("GET", "/all_defined_alerts", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Create a new ResponseRecorder to record the response
+			rr := httptest.NewRecorder()
+
+			// Call the handler
+			handler := api.GetAllDefinedAlertsHandler(context.Background(), tt.alertsDefined)
+
+			// Serve the HTTP request
+			handler.ServeHTTP(rr, req)
+
+			// Check the response status code
+			if rr.Code != http.StatusOK {
+				t.Errorf("expected status 200 OK, got %v", rr.Code)
+			}
+
+			// Check the response body
+			got := rr.Body.Bytes()
+			if string(got) != string(tt.expected) {
+				t.Errorf("expected response body %s, got %s", string(tt.expected), string(got))
+			}
+
+		})
+	}
+
+}

--- a/service/tests/trade_service_get_trades_by_Item_test.go
+++ b/service/tests/trade_service_get_trades_by_Item_test.go
@@ -1,4 +1,4 @@
-package tests
+package service
 
 import (
 	"Price_Notification_System/models"
@@ -22,7 +22,7 @@ func TestTradeService_GetTradesByItem(t *testing.T) {
 	}
 
 	tests := []testDefGetTradesByItem{
-		{instanceName: "test1 - Get trades for hulk item", tradeStore: store.NewInMemoryTradeStoreWithData(map[time.Time]models.HistoricalDataValues{
+		{instanceName: "test1 - Get trades for hulk item", tradeStore: store.NewInMemoryTradeStoreWithData(&map[time.Time]models.HistoricalDataValues{
 			time.Date(2024, 3, 10, 23, 20, 0, 0, time.UTC): {Object: "hulk", Price: 975},
 			time.Date(2025, 1, 12, 3, 20, 0, 0, time.UTC):  {Object: "spider man", Price: 975},
 			time.Date(2024, 5, 15, 3, 15, 30, 0, time.UTC): {Object: "hulk", Price: 854},
@@ -32,7 +32,7 @@ func TestTradeService_GetTradesByItem(t *testing.T) {
 				{Date: time.Date(2024, 5, 15, 3, 15, 30, 0, time.UTC), HistoricalDataValues: models.HistoricalDataValues{Object: "hulk", Price: 854}},
 			},
 			expectedError: nil, wantErr: false},
-		{instanceName: "test2 - Get trades for wolverine item", tradeStore: store.NewInMemoryTradeStoreWithData(map[time.Time]models.HistoricalDataValues{
+		{instanceName: "test2 - Get trades for wolverine item", tradeStore: store.NewInMemoryTradeStoreWithData(&map[time.Time]models.HistoricalDataValues{
 			time.Date(2023, 3, 12, 23, 20, 0, 0, time.UTC): {Object: "wolverine", Price: 975},
 			time.Date(2025, 1, 15, 3, 20, 0, 0, time.UTC):  {Object: "superman", Price: 250},
 			time.Date(2024, 5, 18, 3, 15, 30, 0, time.UTC): {Object: "wolverine", Price: 790},
@@ -42,7 +42,7 @@ func TestTradeService_GetTradesByItem(t *testing.T) {
 				{Date: time.Date(2024, 5, 18, 3, 15, 30, 0, time.UTC), HistoricalDataValues: models.HistoricalDataValues{Object: "wolverine", Price: 790}},
 			},
 			expectedError: nil, wantErr: false},
-		{instanceName: "test3 - Ensure no matching trades are handled correctly", tradeStore: store.NewInMemoryTradeStoreWithData(map[time.Time]models.HistoricalDataValues{
+		{instanceName: "test3 - Ensure no matching trades are handled correctly", tradeStore: store.NewInMemoryTradeStoreWithData(&map[time.Time]models.HistoricalDataValues{
 			time.Date(2023, 3, 12, 23, 20, 0, 0, time.UTC): {Object: "wolverine", Price: 975},
 			time.Date(2025, 1, 15, 3, 20, 0, 0, time.UTC):  {Object: "superman", Price: 250},
 			time.Date(2024, 5, 18, 3, 15, 30, 0, time.UTC): {Object: "wolverine", Price: 790},

--- a/service/tests/trade_service_process_alerts_test.go
+++ b/service/tests/trade_service_process_alerts_test.go
@@ -1,4 +1,4 @@
-package tests
+package service
 
 import (
 	"Price_Notification_System/models"

--- a/service/trade_service.go
+++ b/service/trade_service.go
@@ -62,3 +62,15 @@ func ProcessAlerts(
 	}
 
 }
+
+func CreateNewAlert(
+	ctx context.Context,
+	alertStore store.AlertDefStore,
+	item string,
+	newAlertDef models.AlertValues,
+) (err error) {
+
+	// Add the alert to the alert store
+	alertStore.AddAlert(item, newAlertDef)
+	return nil
+}

--- a/store/alert_def_store.go
+++ b/store/alert_def_store.go
@@ -5,4 +5,5 @@ import "Price_Notification_System/models"
 type AlertDefStore interface {
 	AddAlert(item string, newAlertDef models.AlertValues)
 	GetAlertsByItem(item string) ([]models.AlertsByItemReturned, error)
+	GetAllAlerts() ([]models.AlertDef, error)
 }

--- a/store/in_memory_alert_def_store.go
+++ b/store/in_memory_alert_def_store.go
@@ -2,11 +2,12 @@ package store
 
 import (
 	"Price_Notification_System/models"
+	"fmt"
 )
 
 // InMemoryAlertStore - concrete implementation of the AlertDefStore interface
 type InMemoryAlertStore struct {
-	Data []models.AlertDef
+	data []models.AlertDef
 }
 
 // compile time check to ensure that inMemoryTradeStore implements the TradeStore interface
@@ -15,26 +16,26 @@ var _ AlertDefStore = &InMemoryAlertStore{}
 
 func NewInMemoryAlertStore() AlertDefStore {
 	return &InMemoryAlertStore{
-		Data: make([]models.AlertDef, 0, 20),
+		data: make([]models.AlertDef, 0, 20),
 	}
 }
 
 func NewInMemoryAlertStoreWithData(data *[]models.AlertDef) AlertDefStore {
 	return &InMemoryAlertStore{
-		Data: *data,
+		data: *data,
 	}
 }
 
 // AddAlert - adds a new alert to the alerts active - i.e. the private memory store used to facilitate easier testing
 func (i *InMemoryAlertStore) AddAlert(itemToAlert string, newAlertDef models.AlertValues) {
 	//i.data[it = newAlertDef
-	i.Data = append(i.Data, models.AlertDef{Item: itemToAlert, AlertValues: newAlertDef})
+	i.data = append(i.data, models.AlertDef{Item: itemToAlert, AlertValues: newAlertDef})
 }
 
 // GetAlertsByItem - retrieves the alerts for a specific item
 func (i *InMemoryAlertStore) GetAlertsByItem(item string) (data []models.AlertsByItemReturned, err error) {
 	var matchingData models.AlertsByItemReturned
-	for _, v := range i.Data {
+	for _, v := range i.data {
 
 		if v.Item == item {
 			matchingData = models.AlertsByItemReturned{
@@ -51,5 +52,14 @@ func (i *InMemoryAlertStore) GetAlertsByItem(item string) (data []models.AlertsB
 		return data, nil
 	} else {
 		return nil, models.ErrNoAlertsForItemFound
+	}
+}
+
+// GetAllAlerts - retrieves all the alerts
+func (i *InMemoryAlertStore) GetAllAlerts() (data []models.AlertDef, err error) {
+	if len(i.data) > 0 {
+		return i.data, nil
+	} else {
+		return nil, fmt.Errorf("no alerts found")
 	}
 }

--- a/store/in_memory_alert_def_store.go
+++ b/store/in_memory_alert_def_store.go
@@ -6,7 +6,7 @@ import (
 
 // InMemoryAlertStore - concrete implementation of the AlertDefStore interface
 type InMemoryAlertStore struct {
-	data []models.AlertDef
+	Data []models.AlertDef
 }
 
 // compile time check to ensure that inMemoryTradeStore implements the TradeStore interface
@@ -15,26 +15,26 @@ var _ AlertDefStore = &InMemoryAlertStore{}
 
 func NewInMemoryAlertStore() AlertDefStore {
 	return &InMemoryAlertStore{
-		data: make([]models.AlertDef, 0, 20),
+		Data: make([]models.AlertDef, 0, 20),
 	}
 }
 
 func NewInMemoryAlertStoreWithData(data *[]models.AlertDef) AlertDefStore {
 	return &InMemoryAlertStore{
-		data: *data,
+		Data: *data,
 	}
 }
 
 // AddAlert - adds a new alert to the alerts active - i.e. the private memory store used to facilitate easier testing
 func (i *InMemoryAlertStore) AddAlert(itemToAlert string, newAlertDef models.AlertValues) {
 	//i.data[it = newAlertDef
-	i.data = append(i.data, models.AlertDef{Item: itemToAlert, AlertValues: newAlertDef})
+	i.Data = append(i.Data, models.AlertDef{Item: itemToAlert, AlertValues: newAlertDef})
 }
 
 // GetAlertsByItem - retrieves the alerts for a specific item
 func (i *InMemoryAlertStore) GetAlertsByItem(item string) (data []models.AlertsByItemReturned, err error) {
 	var matchingData models.AlertsByItemReturned
-	for _, v := range i.data {
+	for _, v := range i.Data {
 
 		if v.Item == item {
 			matchingData = models.AlertsByItemReturned{


### PR DESCRIPTION
Created functions for:
creating a new alert.
retrieve all currently defined alerts.
The retrieve all currently define alerts wasn't working - so created a unit test to see where the error was. Unit test showed results weren't being marshalled to JSON correctly. This turned out to be 'in_memory_alert_def_store' had a private element.  Changed to public and it now works